### PR TITLE
Add rack-cors restrictions

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins '*'
+    origins 'penpost-web.vercel.app', 'http://localhost:3000'
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
#### Purpose: 
> Check all that apply.
- [ ] Feature
- [X] Refactor
- [ ] Bug Fix 
- [ ] Clean Up
### What does this PR do? 
- Specified specific hosts/origins in rackcors config
- specifically our front end vercel and localhost 3000
- 
### Problems Encountered & Resulting Solutions  
We will see! none so far

### Steps To Take
- may need to add the following code for rails 6:
- # Rails.application.config.hosts << "penpost-web.vercel.app/"
# Rails.application.config.hosts << "local..."


#### Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My code follows the style guidelines of this project
- [ ] I have used tests to prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my change
